### PR TITLE
Added pagination

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -8,15 +8,27 @@ class CreditSimulator {
         this.simulationsList = document.getElementById('simulationsList');
         this.refreshBtn = document.getElementById('refreshBtn');
         
+        // Pagination state
+        this.currentPage = this.getPageFromUrl();
+        this.pageSize = 3; // Fixed at 3 items per page
+        this.totalPages = 1;
+        this.paginationData = null;
+        
         this.init();
     }
     
     init() {
         this.form.addEventListener('submit', this.handleFormSubmit.bind(this));
-        this.refreshBtn.addEventListener('click', this.loadSimulations.bind(this));
+        this.refreshBtn.addEventListener('click', () => this.loadSimulations(this.currentPage));
+        
+        // Handle browser back/forward buttons
+        window.addEventListener('popstate', () => {
+            this.currentPage = this.getPageFromUrl();
+            this.loadSimulations(this.currentPage);
+        });
         
         // Load previous simulations on page load
-        this.loadSimulations();
+        this.loadSimulations(this.currentPage);
         
         // Add slider handler only (removed income formatting)
         this.setupLoanSlider();
@@ -45,7 +57,8 @@ class CreditSimulator {
             const formData = this.getFormData();
             const response = await this.submitSimulation(formData);
             this.showResult(response);
-            this.loadSimulations(); // Refresh the list
+            // Go to page 1 after new submission (newest first)
+            this.goToPage(1);
         } catch (error) {
             this.showError(error.message);
         } finally {
@@ -99,16 +112,25 @@ class CreditSimulator {
         return result;
     }
     
-    async loadSimulations() {
+    async loadSimulations(page = 1) {
         try {
-            const response = await fetch('/api/simulations');
+            const response = await fetch(`/api/simulations?page=${page}&limit=${this.pageSize}`);
             const data = await response.json();
             
             if (!response.ok) {
                 throw new Error(data.error || 'Failed to load simulations');
             }
             
+            // Store pagination data
+            this.paginationData = data.pagination;
+            this.totalPages = data.pagination.totalPages;
+            this.currentPage = data.pagination.page;
+            
+            // Update URL without reload
+            this.updateUrl(this.currentPage);
+            
             this.renderSimulations(data.simulations);
+            this.renderPagination();
         } catch (error) {
             this.simulationsList.innerHTML = `
                 <div class="alert alert-warning">
@@ -116,6 +138,11 @@ class CreditSimulator {
                     Failed to load previous simulations: ${error.message}
                 </div>
             `;
+            // Hide pagination on error
+            const paginationControls = document.getElementById('paginationControls');
+            if (paginationControls) {
+                paginationControls.style.display = 'none';
+            }
         }
     }
     
@@ -243,6 +270,100 @@ class CreditSimulator {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
+    }
+    
+    getPageFromUrl() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const page = parseInt(urlParams.get('page')) || 1;
+        return page > 0 ? page : 1;
+    }
+    
+    updateUrl(page) {
+        const url = new URL(window.location);
+        if (page === 1) {
+            url.searchParams.delete('page');
+        } else {
+            url.searchParams.set('page', page);
+        }
+        window.history.pushState({}, '', url);
+    }
+    
+    goToPage(page) {
+        if (page < 1 || (this.totalPages > 0 && page > this.totalPages)) {
+            return;
+        }
+        this.currentPage = page;
+        this.loadSimulations(page);
+    }
+    
+    renderPagination() {
+        const paginationControls = document.getElementById('paginationControls');
+        if (!paginationControls || !this.paginationData) {
+            return;
+        }
+        
+        const { page, totalPages, hasNext, hasPrev, total } = this.paginationData;
+        
+        // Hide pagination if only one page or no results
+        if (totalPages <= 1) {
+            paginationControls.style.display = 'none';
+            return;
+        }
+        
+        paginationControls.style.display = 'flex';
+        
+        let paginationHtml = '<nav aria-label="Simulation pages"><ul class="pagination mb-0">';
+        
+        // Previous button
+        paginationHtml += `
+            <li class="page-item ${!hasPrev ? 'disabled' : ''}">
+                <a class="page-link" href="#" data-page="${page - 1}" ${!hasPrev ? 'tabindex="-1" aria-disabled="true"' : ''}>
+                    <i class="bi bi-chevron-left"></i> Previous
+                </a>
+            </li>
+        `;
+        
+        // Page numbers
+        for (let i = 1; i <= totalPages; i++) {
+            // Show first page, last page, current page, and pages around current
+            if (i === 1 || i === totalPages || (i >= page - 2 && i <= page + 2)) {
+                paginationHtml += `
+                    <li class="page-item ${i === page ? 'active' : ''}">
+                        <a class="page-link" href="#" data-page="${i}">
+                            ${i}
+                            ${i === page ? '<span class="visually-hidden">(current)</span>' : ''}
+                        </a>
+                    </li>
+                `;
+            } else if (i === page - 3 || i === page + 3) {
+                // Show ellipsis
+                paginationHtml += '<li class="page-item disabled"><span class="page-link">...</span></li>';
+            }
+        }
+        
+        // Next button
+        paginationHtml += `
+            <li class="page-item ${!hasNext ? 'disabled' : ''}">
+                <a class="page-link" href="#" data-page="${page + 1}" ${!hasNext ? 'tabindex="-1" aria-disabled="true"' : ''}>
+                    Next <i class="bi bi-chevron-right"></i>
+                </a>
+            </li>
+        `;
+        
+        paginationHtml += '</ul></nav>';
+        
+        paginationControls.innerHTML = paginationHtml;
+        
+        // Add click handlers to pagination links
+        paginationControls.querySelectorAll('.page-link').forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const targetPage = parseInt(e.currentTarget.dataset.page);
+                if (targetPage && !e.currentTarget.closest('.disabled')) {
+                    this.goToPage(targetPage);
+                }
+            });
+        });
     }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -190,6 +190,11 @@
                                 <i class="bi bi-hourglass-split"></i> Loading...
                             </div>
                         </div>
+                        
+                        <!-- Pagination Controls -->
+                        <div id="paginationControls" class="d-flex justify-content-center mt-4" style="display: none !important;">
+                            <!-- Pagination will be rendered here by JavaScript -->
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -89,6 +89,26 @@ class Database {
     });
   }
 
+  async getCustomersPaginated(page = 1, limit = 3) {
+    return new Promise((resolve, reject) => {
+      // Validate and sanitize inputs
+      const pageNum = Math.max(1, parseInt(page) || 1);
+      const limitNum = Math.max(1, Math.min(100, parseInt(limit) || 3)); // Max 100 items per page
+      const offset = (pageNum - 1) * limitNum;
+      
+      const selectSQL = 'SELECT * FROM customers ORDER BY createdAt DESC LIMIT ? OFFSET ?';
+      
+      this.db.all(selectSQL, [limitNum, offset], (err, rows) => {
+        if (err) {
+          console.error('Error fetching paginated customers:', err.message);
+          reject(err);
+        } else {
+          resolve(rows);
+        }
+      });
+    });
+  }
+
   async getCustomerById(id) {
     return new Promise((resolve, reject) => {
       const selectSQL = 'SELECT * FROM customers WHERE id = ?';

--- a/src/routes/simulation.js
+++ b/src/routes/simulation.js
@@ -99,14 +99,35 @@ router.post('/simulate', validateCustomerData, handleValidationErrors, async (re
 
 /**
  * GET /api/simulations
- * Get all previous simulations
+ * Get all previous simulations with pagination support
+ * Query params: page (default 1), limit (default 3)
  */
 router.get('/simulations', async (req, res) => {
   try {
-    const simulations = await database.getAllCustomers();
+    // Parse pagination parameters
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 3;
+    
+    // Validate parameters
+    if (page < 1 || limit < 1 || limit > 100) {
+      return res.status(400).json({
+        error: 'Invalid pagination parameters',
+        message: 'Page must be >= 1 and limit must be between 1 and 100'
+      });
+    }
+    
+    // Fetch paginated data and total count in parallel
+    const [simulations, total] = await Promise.all([
+      database.getCustomersPaginated(page, limit),
+      database.countCustomers()
+    ]);
+    
+    // Calculate pagination metadata
+    const totalPages = Math.ceil(total / limit);
+    const hasNext = page < totalPages;
+    const hasPrev = page > 1;
     
     res.json({
-      count: simulations.length,
       simulations: simulations.map(sim => ({
         id: sim.id,
         name: sim.name,
@@ -114,7 +135,15 @@ router.get('/simulations', async (req, res) => {
         riskCategory: sim.riskCategory,
         loanAmount: sim.loanAmount,
         createdAt: sim.createdAt
-      }))
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages,
+        hasNext,
+        hasPrev
+      }
     });
     
   } catch (error) {


### PR DESCRIPTION
This pull request implements pagination support for the simulations list in the credit simulator application. The changes span both the frontend and backend, allowing users to navigate through previous simulations page by page, improving performance and usability for large datasets. The frontend now displays pagination controls and updates the URL to reflect the current page, while the backend API supports paginated queries and returns pagination metadata.

**Frontend pagination and UI updates:**

* Added pagination state and logic to the `CreditSimulator` class in `public/app.js`, including methods for updating the URL, handling browser navigation, and rendering pagination controls. The simulations list now loads only the current page of results and updates as users navigate. [[1]](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45R11-R31) [[2]](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45L102-R145) [[3]](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45R274-R367)
* The simulations list is refreshed to the first page after a new simulation is submitted, ensuring users see the most recent entry.
* Added a new `div` with `id="paginationControls"` to `public/index.html` for rendering pagination UI.

**Backend pagination support:**

* Added a new `getCustomersPaginated` method to the `Database` class in `src/database/database.js` to fetch customers with limit and offset for pagination.
* Updated the `/api/simulations` route in `src/routes/simulation.js` to accept `page` and `limit` query parameters, validate them, and return paginated results along with pagination metadata (such as `totalPages`, `hasNext`, `hasPrev`).