### PR TITLE
added pag in parallel

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -104,11 +104,21 @@ paths:
 
   /simulations:
     get:
-      summary: Get all simulations
-      description: Retrieve a list of all previous credit score simulations.
+      summary: Get simulations (paginated)
+      description: Retrieve a paginated list of previous credit score simulations. Returns 3 items per page.
       operationId: getAllSimulations
       tags:
         - Credit Simulation
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: Page number (1-based). Invalid or missing values default to 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
       responses:
         '200':
           description: List of simulations retrieved successfully
@@ -349,14 +359,29 @@ components:
     SimulationsList:
       type: object
       properties:
-        count:
-          type: integer
-          description: Total number of simulations
-          example: 2
         simulations:
           type: array
           items:
             $ref: '#/components/schemas/SimulationSummary'
+        pagination:
+          type: object
+          properties:
+            total:
+              type: integer
+              description: Total number of simulations across all pages
+              example: 10
+            page:
+              type: integer
+              description: Current page number
+              example: 1
+            pageSize:
+              type: integer
+              description: Number of simulations per page
+              example: 3
+            totalPages:
+              type: integer
+              description: Total number of pages
+              example: 4
 
     ScoringCriteria:
       type: object

--- a/public/app.js
+++ b/public/app.js
@@ -7,16 +7,20 @@ class CreditSimulator {
         this.errorCard = document.getElementById('errorCard');
         this.simulationsList = document.getElementById('simulationsList');
         this.refreshBtn = document.getElementById('refreshBtn');
+        this.currentPage = 1;
         
         this.init();
     }
     
     init() {
         this.form.addEventListener('submit', this.handleFormSubmit.bind(this));
-        this.refreshBtn.addEventListener('click', this.loadSimulations.bind(this));
+        this.refreshBtn.addEventListener('click', () => {
+            this.currentPage = 1;
+            this.loadSimulations(1);
+        });
         
         // Load previous simulations on page load
-        this.loadSimulations();
+        this.loadSimulations(1);
         
         // Add slider handler only (removed income formatting)
         this.setupLoanSlider();
@@ -45,7 +49,8 @@ class CreditSimulator {
             const formData = this.getFormData();
             const response = await this.submitSimulation(formData);
             this.showResult(response);
-            this.loadSimulations(); // Refresh the list
+            this.currentPage = 1;
+            this.loadSimulations(1); // Refresh the list, reset to page 1
         } catch (error) {
             this.showError(error.message);
         } finally {
@@ -99,9 +104,10 @@ class CreditSimulator {
         return result;
     }
     
-    async loadSimulations() {
+    async loadSimulations(page = this.currentPage) {
+        this.currentPage = page;
         try {
-            const response = await fetch('/api/simulations');
+            const response = await fetch(`/api/simulations?page=${page}`);
             const data = await response.json();
             
             if (!response.ok) {
@@ -109,6 +115,7 @@ class CreditSimulator {
             }
             
             this.renderSimulations(data.simulations);
+            this.renderPagination(data.pagination);
         } catch (error) {
             this.simulationsList.innerHTML = `
                 <div class="alert alert-warning">
@@ -116,7 +123,62 @@ class CreditSimulator {
                     Failed to load previous simulations: ${error.message}
                 </div>
             `;
+            const paginationContainer = document.getElementById('pagination-container');
+            if (paginationContainer) paginationContainer.innerHTML = '';
         }
+    }
+
+    renderPagination(pagination) {
+        const container = document.getElementById('pagination-container');
+        if (!container) return;
+
+        if (!pagination || pagination.totalPages <= 1) {
+            container.innerHTML = '';
+            return;
+        }
+
+        const { page, totalPages } = pagination;
+        const items = [];
+
+        items.push(`
+            <li class="page-item ${page === 1 ? 'disabled' : ''}">
+                <button class="page-link" data-page="${page - 1}" ${page === 1 ? 'disabled' : ''}>
+                    <i class="bi bi-chevron-left"></i>
+                </button>
+            </li>
+        `);
+
+        for (let i = 1; i <= totalPages; i++) {
+            items.push(`
+                <li class="page-item ${i === page ? 'active' : ''}">
+                    <button class="page-link" data-page="${i}">${i}</button>
+                </li>
+            `);
+        }
+
+        items.push(`
+            <li class="page-item ${page === totalPages ? 'disabled' : ''}">
+                <button class="page-link" data-page="${page + 1}" ${page === totalPages ? 'disabled' : ''}>
+                    <i class="bi bi-chevron-right"></i>
+                </button>
+            </li>
+        `);
+
+        container.innerHTML = `
+            <nav aria-label="Simulation history pagination">
+                <ul class="pagination mb-0">
+                    ${items.join('')}
+                </ul>
+            </nav>
+        `;
+
+        container.querySelectorAll('.page-link:not([disabled])').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const targetPage = parseInt(btn.dataset.page, 10);
+                this.currentPage = targetPage;
+                this.loadSimulations(targetPage);
+            });
+        });
     }
     
     renderSimulations(simulations) {

--- a/public/index.html
+++ b/public/index.html
@@ -190,6 +190,7 @@
                                 <i class="bi bi-hourglass-split"></i> Loading...
                             </div>
                         </div>
+                        <div id="pagination-container" class="mt-3 d-flex justify-content-center"></div>
                     </div>
                 </div>
             </div>

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -89,6 +89,25 @@ class Database {
     });
   }
 
+  async getCustomersPaginated(limit, offset) {
+    return new Promise((resolve, reject) => {
+      const selectSQL = `
+        SELECT id, name, score, riskCategory, loanAmount, createdAt
+        FROM customers
+        ORDER BY createdAt DESC
+        LIMIT ? OFFSET ?
+      `;
+      this.db.all(selectSQL, [limit, offset], (err, rows) => {
+        if (err) {
+          console.error('Error fetching customers:', err.message);
+          reject(err);
+        } else {
+          resolve(rows);
+        }
+      });
+    });
+  }
+
   async getCustomerById(id) {
     return new Promise((resolve, reject) => {
       const selectSQL = 'SELECT * FROM customers WHERE id = ?';

--- a/src/routes/simulation.js
+++ b/src/routes/simulation.js
@@ -5,6 +5,8 @@ const { calculateCreditScore, getScoringCriteria } = require('../services/credit
 
 const router = express.Router();
 
+const PAGE_SIZE = 3;
+
 // Validation middleware
 const validateCustomerData = [
   body('name')
@@ -99,14 +101,23 @@ router.post('/simulate', validateCustomerData, handleValidationErrors, async (re
 
 /**
  * GET /api/simulations
- * Get all previous simulations
+ * Get paginated previous simulations
  */
 router.get('/simulations', async (req, res) => {
   try {
-    const simulations = await database.getAllCustomers();
-    
+    let page = parseInt(req.query.page, 10);
+    if (!Number.isInteger(page) || page < 1) page = 1;
+
+    const offset = (page - 1) * PAGE_SIZE;
+
+    const [total, simulations] = await Promise.all([
+      database.countCustomers(),
+      database.getCustomersPaginated(PAGE_SIZE, offset)
+    ]);
+
+    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
     res.json({
-      count: simulations.length,
       simulations: simulations.map(sim => ({
         id: sim.id,
         name: sim.name,
@@ -114,9 +125,15 @@ router.get('/simulations', async (req, res) => {
         riskCategory: sim.riskCategory,
         loanAmount: sim.loanAmount,
         createdAt: sim.createdAt
-      }))
+      })),
+      pagination: {
+        total,
+        page,
+        pageSize: PAGE_SIZE,
+        totalPages
+      }
     });
-    
+
   } catch (error) {
     console.error('Error in /simulations:', error);
     res.status(500).json({

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -90,29 +90,35 @@ describe('API Endpoints', () => {
   });
 
   describe('GET /api/simulations', () => {
-    test('should return list of simulations', async () => {
+    const simulationData = {
+      name: 'Pagination Test User',
+      age: 30,
+      annualIncome: 50000,
+      debtToIncomeRatio: 0.3,
+      loanAmount: 10000,
+      creditHistory: 'good'
+    };
+
+    test('should return paginated list of simulations', async () => {
       const response = await request(app)
         .get('/api/simulations')
         .expect(200);
 
-      expect(response.body).toHaveProperty('count');
       expect(response.body).toHaveProperty('simulations');
+      expect(response.body).toHaveProperty('pagination');
       expect(Array.isArray(response.body.simulations)).toBe(true);
-      expect(typeof response.body.count).toBe('number');
+
+      const { pagination } = response.body;
+      expect(pagination).toHaveProperty('total');
+      expect(pagination).toHaveProperty('page');
+      expect(pagination).toHaveProperty('pageSize');
+      expect(pagination).toHaveProperty('totalPages');
+      expect(typeof pagination.total).toBe('number');
+      expect(pagination.pageSize).toBe(3);
     });
 
     test('should return simulations in correct format', async () => {
-      // First create a simulation
-      await request(app)
-        .post('/api/simulate')
-        .send({
-          name: 'Test User',
-          age: 30,
-          annualIncome: 50000,
-          debtToIncomeRatio: 0.4,
-          loanAmount: 20000,
-          creditHistory: 'good'
-        });
+      await request(app).post('/api/simulate').send(simulationData);
 
       const response = await request(app)
         .get('/api/simulations')
@@ -126,6 +132,44 @@ describe('API Endpoints', () => {
         expect(simulation).toHaveProperty('riskCategory');
         expect(simulation).toHaveProperty('loanAmount');
         expect(simulation).toHaveProperty('createdAt');
+      }
+    });
+
+    test('should return at most 3 simulations per page', async () => {
+      const response = await request(app)
+        .get('/api/simulations?page=1')
+        .expect(200);
+
+      expect(response.body.simulations.length).toBeLessThanOrEqual(3);
+    });
+
+    test('should return non-overlapping results for page 1 and page 2', async () => {
+      // Ensure at least 4 records exist
+      for (let i = 0; i < 4; i++) {
+        await request(app).post('/api/simulate').send({ ...simulationData, name: `Paging User ${i}` });
+      }
+
+      const [page1, page2] = await Promise.all([
+        request(app).get('/api/simulations?page=1').expect(200),
+        request(app).get('/api/simulations?page=2').expect(200)
+      ]);
+
+      expect(page1.body.simulations.length).toBe(3);
+      expect(page2.body.simulations.length).toBeGreaterThanOrEqual(1);
+
+      const page1Ids = page1.body.simulations.map(s => s.id);
+      const page2Ids = page2.body.simulations.map(s => s.id);
+      expect(page1Ids.some(id => page2Ids.includes(id))).toBe(false);
+    });
+
+    test('should default to page 1 for invalid page values', async () => {
+      const page1Response = await request(app).get('/api/simulations?page=1').expect(200);
+      const page1Ids = page1Response.body.simulations.map(s => s.id);
+
+      for (const badPage of ['0', '-1', 'abc']) {
+        const response = await request(app).get(`/api/simulations?page=${badPage}`).expect(200);
+        expect(response.body.pagination.page).toBe(1);
+        expect(response.body.simulations.map(s => s.id)).toEqual(page1Ids);
       }
     });
   });


### PR DESCRIPTION
This pull request introduces pagination to the simulations history feature, updating both the backend API and the frontend to support and display paginated results. The OpenAPI documentation, backend implementation, frontend code, and tests have all been updated to ensure a consistent and user-friendly paginated experience.

**Backend API and Data Layer:**

* Added pagination support to the `/api/simulations` endpoint, including `page` query parameter handling, calculation of total pages, and a new `pagination` object in the response. The database layer now includes a `getCustomersPaginated` method. [[1]](diffhunk://#diff-ed814d8db476adc3c70fcd800075da525de00049de91451d52a22bee314367b2L102-R134) [[2]](diffhunk://#diff-a9c859ce4ee54e02520f503fba26ec62de5e44e33d493b736ec923a12f117d0fR92-R110)
* Updated OpenAPI documentation (`docs/api.yaml`) to describe the paginated endpoint, new `pagination` response schema, and the new `page` query parameter. [[1]](diffhunk://#diff-1c9072d38a3db7fcd859ee8669e48250c5abfcbaecd91df1df8c88a7759dbe88L107-R121) [[2]](diffhunk://#diff-1c9072d38a3db7fcd859ee8669e48250c5abfcbaecd91df1df8c88a7759dbe88L352-R384)

**Frontend (UI/UX):**

* Updated the frontend (`public/app.js` and `public/index.html`) to request simulations by page, reset to page 1 on refresh or after submitting a simulation, and render a pagination control allowing users to navigate between pages. [[1]](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45R10-R23) [[2]](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45L48-R53) [[3]](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45L102-R181) [[4]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR193)

**Testing:**

* Enhanced API tests to verify pagination behavior, including page size limits, non-overlapping results between pages, and defaulting to page 1 for invalid page values. [[1]](diffhunk://#diff-8a3eb799e63916b7d0a306ae2f7ead84b72c44ec9959a099d7279890da95445eL93-R121) [[2]](diffhunk://#diff-8a3eb799e63916b7d0a306ae2f7ead84b72c44ec9959a099d7279890da95445eR137-R174)